### PR TITLE
Add badges to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
 SPDX-License-Identifier: CC0-1.0    
 -->
 
+[![GitHub Actions Build Status](https://github.com/lmos-ai/arc/actions/workflows/gradle.yml/badge.svg?branch=main)](https://github.com/lmos-ai/arc/actions/workflows/gradle.yml)
+[![GitHub Actions Publish Status](https://github.com/lmos-ai/arc/actions/workflows/gradle-publish.yml/badge.svg?branch=main)](https://github.com/lmos-ai/arc/actions/workflows/gradle-publish.yml)
+[![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
 # The Arc Project
 
 The goal of the Arc project is to utilize the power of Kotlin DSL and Kotlin Scripting to define

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: CC0-1.0
 [![GitHub Actions Build Status](https://github.com/lmos-ai/arc/actions/workflows/gradle.yml/badge.svg?branch=main)](https://github.com/lmos-ai/arc/actions/workflows/gradle.yml)
 [![GitHub Actions Publish Status](https://github.com/lmos-ai/arc/actions/workflows/gradle-publish.yml/badge.svg?branch=main)](https://github.com/lmos-ai/arc/actions/workflows/gradle-publish.yml)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 # The Arc Project
 


### PR DESCRIPTION
This PR adds typical badges to the project home page:

<img width="909" alt="Bildschirmfoto 2024-08-09 um 12 17 58" src="https://github.com/user-attachments/assets/15eeba9f-2404-4e9c-93bf-83dec0a33907">
