### PR TITLE
Do not run the dependency graph update on PR builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,4 +68,5 @@ jobs:
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
     - name: Generate and submit dependency graph
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0


### PR DESCRIPTION
... as this results in an error status, see e.g. [here](https://github.com/lmos-ai/arc/actions/runs/10317720484/job/28562580652?pr=13).