### PR TITLE
bug: disable artifact signing when publishing artifacts

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -42,7 +42,7 @@ jobs:
     # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
     # the publishing section of your build.gradle
     - name: Publish to GitHub Packages
-      run: ./gradlew publish
+      run: ./gradlew publish -x sign
       env:
         GITHUB_USER: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release [publishing workflow is failing](https://github.com/lmos-ai/arc/actions/workflows/gradle-publish.yml) due to missing signing keys.

This PR fixes this by disabling artifact signing.
Please note that this is a quick fix. To do proper releases, a signing key must be created and correctly configured in the pipeline. I have created https://github.com/lmos-ai/arc/issues/17 for this as a follow-up.