### PR TITLE
chore: enable artifact signing

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -42,7 +42,9 @@ jobs:
     # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
     # the publishing section of your build.gradle
     - name: Publish to GitHub Packages
-      run: ./gradlew publish -x sign
+      run: ./gradlew publish
       env:
         GITHUB_USER: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PGP_SECRET_KEY: ${{ secrets.PGP_SECRET_KEY }}
+        PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,7 +102,7 @@ subprojects {
 
         repositories {
             maven {
-                name = "github"
+                name = "GitHubPackages"
                 url = URI("https://maven.pkg.github.com/lmos-ai/arc")
                 credentials {
                     username = findProperty("GITHUB_USER")?.toString() ?: getenv("GITHUB_USER")
@@ -112,9 +112,15 @@ subprojects {
         }
 
         configure<SigningExtension> {
+            useInMemoryPgpKeys(
+                findProperty("signing.keyId") as String?,
+                System.getenv("PGP_SECRET_KEY"),
+                System.getenv("PGP_PASSPHRASE")
+            )
             sign(publications)
         }
     }
+
     if (!project.name.endsWith("-bom")) {
         dependencies {
             val kotlinXVersion = "1.8.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ org.gradle.dependency.verification=lenient
 #org.gradle.configuration-cache=true
 #org.gradle.configuration-cache.problems=warn
 org.gradle.configureondemand=true
+signing.keyId=19DF17CDF6EBCA2D128E0DF8614219C26C6267E3


### PR DESCRIPTION
This enables artifact signing when publishing them.
I've set up to organization secrets `PGP_SECRET_KEY` and `PGP_PASSPHRASE`, which can be used by such workflows.