### PR TITLE
fix: modifies regex to match case-insensitive useCaseId

### DIFF
--- a/arc-assistants/src/main/kotlin/common/UseCaseConstants.kt
+++ b/arc-assistants/src/main/kotlin/common/UseCaseConstants.kt
@@ -1,0 +1,5 @@
+package org.eclipse.lmos.arc.assistants.support.common
+
+object UseCaseConstants {
+    val USE_CASE_ID_REGEX = "<ID:(.*?)>".toRegex(RegexOption.IGNORE_CASE)
+}

--- a/arc-assistants/src/main/kotlin/common/UseCaseConstants.kt
+++ b/arc-assistants/src/main/kotlin/common/UseCaseConstants.kt
@@ -1,5 +1,0 @@
-package org.eclipse.lmos.arc.assistants.support.common
-
-object UseCaseConstants {
-    val USE_CASE_ID_REGEX = "<ID:(.*?)>".toRegex(RegexOption.IGNORE_CASE)
-}

--- a/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
@@ -4,18 +4,17 @@
 
 package org.eclipse.lmos.arc.assistants.support.usecases
 
-import org.eclipse.lmos.arc.assistants.support.common.UseCaseConstants.USE_CASE_ID_REGEX
-
 typealias UseCaseId = String
 
 /**
  * Extract the use case id from the assistant message.
  * For example, "<ID:useCaseId>"
  */
+private val useCaseIdRegex = "<ID:(.*?)>".toRegex(RegexOption.IGNORE_CASE)
 
 fun extractUseCaseId(message: String): Pair<String, UseCaseId?> {
-    val id = USE_CASE_ID_REGEX.find(message)?.groupValues?.elementAtOrNull(1)?.trim()
-    val cleanedMessage = message.replace(USE_CASE_ID_REGEX, "").trim()
+    val id = useCaseIdRegex.find(message)?.groupValues?.elementAtOrNull(1)?.trim()
+    val cleanedMessage = message.replace(useCaseIdRegex, "").trim()
     return cleanedMessage to id
 }
 

--- a/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
+++ b/arc-assistants/src/main/kotlin/usecases/UseCaseIdExtractor.kt
@@ -4,17 +4,18 @@
 
 package org.eclipse.lmos.arc.assistants.support.usecases
 
+import org.eclipse.lmos.arc.assistants.support.common.UseCaseConstants.USE_CASE_ID_REGEX
+
 typealias UseCaseId = String
 
 /**
  * Extract the use case id from the assistant message.
  * For example, "<ID:useCaseId>"
  */
-private val useCaseIdRegex = "<ID:(.*?)>".toRegex()
 
 fun extractUseCaseId(message: String): Pair<String, UseCaseId?> {
-    val id = useCaseIdRegex.find(message)?.groupValues?.elementAtOrNull(1)?.trim()
-    val cleanedMessage = message.replace(useCaseIdRegex, "").trim()
+    val id = USE_CASE_ID_REGEX.find(message)?.groupValues?.elementAtOrNull(1)?.trim()
+    val cleanedMessage = message.replace(USE_CASE_ID_REGEX, "").trim()
     return cleanedMessage to id
 }
 

--- a/arc-assistants/src/test/kotlin/usecases/UseCaseIdExtractorTest.kt
+++ b/arc-assistants/src/test/kotlin/usecases/UseCaseIdExtractorTest.kt
@@ -20,6 +20,15 @@ class UseCaseIdExtractorTest {
     }
 
     @Test
+    fun `test case-insensitive use case id extraction`(): Unit = runBlocking {
+        val message = """<id:use_case01>
+                 This is a reply from the LLM."""
+        val (filteredMessage, useCaseId) = extractUseCaseId(message)
+        assertThat(filteredMessage).contains("This is a reply from the LLM.")
+        assertThat(useCaseId).isEqualTo("use_case01")
+    }
+
+    @Test
     fun `test use case null extraction`(): Unit = runBlocking {
         val message = """This is a reply from the LLM."""
         val (filteredMessage, useCaseId) = extractUseCaseId(message)


### PR DESCRIPTION
Idea is to make regex for matching usecaseId case-insensitive so that it matches different cases of usecaseId generated by Bot.