### PR TITLE
feat(mcp): add streamable HTTP client transport option

### DIFF
--- a/arc-mcp/src/main/kotlin/McpClientBuilder.kt
+++ b/arc-mcp/src/main/kotlin/McpClientBuilder.kt
@@ -7,6 +7,7 @@ package org.eclipse.lmos.arc.mcp
 import io.modelcontextprotocol.client.McpAsyncClient
 import io.modelcontextprotocol.client.McpClient
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.eclipse.lmos.arc.core.Result
@@ -14,27 +15,40 @@ import org.eclipse.lmos.arc.core.closeWith
 import org.eclipse.lmos.arc.core.result
 import org.slf4j.LoggerFactory
 import java.io.Closeable
+import java.net.URI
 import java.time.Duration
 
 /**
  * The MCP client.
  *
+ * [transport] selects the wire protocol. Connection URLs are derived from [url]:
+ * - **SSE:** `…/sse` (if [url] already ends with `/sse` it is kept; otherwise `/sse` is appended to the server origin).
+ * - **Streamable HTTP:** server origin + `POST /mcp` (any `/sse` suffix in [url] is stripped for the HTTP client base).
+ *
  * Todo See if we can keep the client open and reuse it. Currently, the client seems to lose connection after a while.
  */
-class McpClientBuilder(private val url: String) : Closeable {
+class McpClientBuilder(
+    private val url: String,
+    private val transport: McpClientTransport = McpClientTransport.SSE,
+) : Closeable {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
     suspend fun <T> execute(fn: suspend (McpAsyncClient, String) -> T): Result<T, Exception> = result<T, Exception> {
         val client = createClient() closeWith { it.closeGracefully().subscribe() }
         val result = client.initialize().awaitSingleOrNull()
-        log.debug("Client connected: $url Result: $result")
+        log.debug("Client connected: $url transport=$transport Result: $result")
         fn(client, url)
     }
 
     private fun createClient(): McpAsyncClient {
-        val fixed = if (url.endsWith("/")) url.substring(0, url.length - 1) else url
-        return McpClient.async(HttpClientSseClientTransport.builder(fixed).build())
+        val mcpTransport = when (transport) {
+            McpClientTransport.SSE ->
+                HttpClientSseClientTransport.builder(sseConnectionUrl(url)).build()
+            McpClientTransport.STREAMABLE_HTTP ->
+                HttpClientStreamableHttpTransport.builder(streamableHttpBaseUrl(url)).endpoint("/mcp").build()
+        }
+        return McpClient.async(mcpTransport)
             .requestTimeout(Duration.ofSeconds(10))
             .capabilities(ClientCapabilities.builder().build())
             .build()
@@ -42,5 +56,30 @@ class McpClientBuilder(private val url: String) : Closeable {
 
     override fun close() {
         // client.close()
+    }
+
+    private companion object {
+        private fun trimTrailingSlash(s: String): String = s.trimEnd('/')
+
+        /** Base URL for streamable client: strip a trailing `/sse` path if present, else use as configured. */
+        private fun streamableHttpBaseUrl(configUrl: String): String {
+            val trimmed = trimTrailingSlash(configUrl)
+            val path = URI.create(trimmed).path.orEmpty()
+            if (!path.endsWith("/sse")) return trimmed
+            val withoutSse = trimTrailingSlash(trimmed.removeSuffix("/sse"))
+            return withoutSse.ifEmpty { originOnly(URI.create(trimmed)) }
+        }
+
+        private fun originOnly(uri: URI): String {
+            val host = uri.host ?: throw IllegalArgumentException("Invalid MCP URL (missing host): $uri")
+            val portPart = if (uri.port == -1) "" else ":${uri.port}"
+            return "${uri.scheme}://$host$portPart"
+        }
+
+        private fun sseConnectionUrl(configUrl: String): String {
+            val trimmed = trimTrailingSlash(configUrl)
+            val path = URI.create(trimmed).path.orEmpty()
+            return if (path.endsWith("/sse")) trimmed else "$trimmed/sse"
+        }
     }
 }

--- a/arc-mcp/src/main/kotlin/McpClientTransport.kt
+++ b/arc-mcp/src/main/kotlin/McpClientTransport.kt
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.eclipse.lmos.arc.mcp
+
+/**
+ * Wire transport used to reach a remote MCP server.
+ *
+ * Configure via `arc.mcp.tools.transport` (also used for [McpPromptRetriever] when enabled),
+ * or `ARC_MCP_TOOLS_TRANSPORT` with [McpToolsByEnvironment].
+ * `/sse` vs `POST …/mcp` is derived from [McpClientTransport] in [McpClientBuilder]; the configured URL can be the server base or include `/sse`.
+ */
+enum class McpClientTransport {
+    /** MCP over HTTP Server-Sent Events (typical URL suffix `/sse`). */
+    SSE,
+
+    /** MCP Streamable HTTP (e.g. Spring AI stateless server `POST /mcp`). */
+    STREAMABLE_HTTP,
+    ;
+
+    companion object {
+        fun fromConfiguration(value: String): McpClientTransport {
+            val n = value.trim().lowercase().replace('-', '_')
+            return when (n) {
+                "sse" -> SSE
+                "streamable_http", "streamablehttp", "mcp" -> STREAMABLE_HTTP
+                else -> throw IllegalArgumentException(
+                    "Unknown MCP client transport '$value'. Expected one of: sse, mcp, streamable-http.",
+                )
+            }
+        }
+    }
+}

--- a/arc-mcp/src/main/kotlin/McpPromptRetriever.kt
+++ b/arc-mcp/src/main/kotlin/McpPromptRetriever.kt
@@ -21,10 +21,13 @@ import java.io.Closeable
 /**
  * PromptRetriever that uses the MCP client to fetch prompts.
  */
-class McpPromptRetriever(private val url: String) : PromptRetriever, Closeable {
+class McpPromptRetriever(
+    private val url: String,
+    private val transport: McpClientTransport = McpClientTransport.SSE,
+) : PromptRetriever, Closeable {
 
     private val log = LoggerFactory.getLogger(javaClass)
-    private val clientBuilder = McpClientBuilder(url)
+    private val clientBuilder = McpClientBuilder(url, transport)
 
     override suspend fun fetchPromptText(name: String, args: Map<String, Any?>): Result<String, PromptException> =
         clientBuilder.execute { client, url ->

--- a/arc-mcp/src/main/kotlin/McpTools.kt
+++ b/arc-mcp/src/main/kotlin/McpTools.kt
@@ -30,11 +30,15 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * An instance of [LLMFunctionLoader] that loads functions from the Model Context Protocol (MCP) server.
  */
-class McpTools(private val url: String, private val cacheDuration: Duration?) :
+class McpTools(
+    private val url: String,
+    private val cacheDuration: Duration?,
+    private val transport: McpClientTransport = McpClientTransport.SSE,
+) :
     LLMFunctionLoader, Closeable {
 
     private val log = LoggerFactory.getLogger(javaClass)
-    private val clientBuilder = McpClientBuilder(url)
+    private val clientBuilder = McpClientBuilder(url, transport)
     private val toolCache = AtomicReference<ToolCacheEntry>()
     private val defaultCacheDuration = Duration.ofMinutes(1)
 

--- a/arc-mcp/src/main/kotlin/McpToolsByEnvironment.kt
+++ b/arc-mcp/src/main/kotlin/McpToolsByEnvironment.kt
@@ -22,9 +22,11 @@ class McpToolsByEnvironment : LLMFunctionLoader {
     private val tools: List<McpTools> by lazy {
         val urls = getEnvironmentValue("ARC_MCP_TOOLS_URLS")?.split(",") ?: return@lazy emptyList()
         val cacheDuration = getEnvironmentValue("ARC_MCP_TOOLS_CACHE_DURATION")?.let { Duration.parse(it) }
-        log.info("Loading MCP tools from URLs: $urls")
+        val transport = getEnvironmentValue("ARC_MCP_TOOLS_TRANSPORT")?.let { McpClientTransport.fromConfiguration(it) }
+            ?: McpClientTransport.SSE
+        log.info("Loading MCP tools from URLs: $urls (transport=$transport)")
         urls.map { url ->
-            McpTools(url.trim(), cacheDuration)
+            McpTools(url.trim(), cacheDuration, transport)
         }
     }
 

--- a/arc-mcp/src/test/kotlin/McpClientTransportTest.kt
+++ b/arc-mcp/src/test/kotlin/McpClientTransportTest.kt
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.lmos.arc.mcp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class McpClientTransportTest {
+
+    @Test
+    fun `parses sse variants`() {
+        assertThat(McpClientTransport.fromConfiguration("sse")).isEqualTo(McpClientTransport.SSE)
+        assertThat(McpClientTransport.fromConfiguration(" SSE ")).isEqualTo(McpClientTransport.SSE)
+    }
+
+    @Test
+    fun `parses streamable variants`() {
+        assertThat(McpClientTransport.fromConfiguration("mcp")).isEqualTo(McpClientTransport.STREAMABLE_HTTP)
+        assertThat(McpClientTransport.fromConfiguration("streamable-http")).isEqualTo(McpClientTransport.STREAMABLE_HTTP)
+        assertThat(McpClientTransport.fromConfiguration("streamable_http")).isEqualTo(McpClientTransport.STREAMABLE_HTTP)
+    }
+
+    @Test
+    fun `rejects unknown`() {
+        assertThatThrownBy { McpClientTransport.fromConfiguration("websocket") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/arc-mcp/src/test/kotlin/McpToolsByEnvironmentTest.kt
+++ b/arc-mcp/src/test/kotlin/McpToolsByEnvironmentTest.kt
@@ -14,7 +14,11 @@ import java.time.DateTimeException
 class McpToolsByEnvironmentTest : TestBase() {
 
     private val originalProperties = mutableMapOf<String, String?>()
-    private val testProperties = listOf("ARC_MCP_TOOLS_URLS", "ARC_MCP_TOOLS_CACHE_DURATION")
+    private val testProperties = listOf(
+        "ARC_MCP_TOOLS_URLS",
+        "ARC_MCP_TOOLS_CACHE_DURATION",
+        "ARC_MCP_TOOLS_TRANSPORT",
+    )
 
     @LocalServerPort
     private var port: Int = 0

--- a/arc-spring-boot-starter/src/main/kotlin/ArcAutoConfiguration.kt
+++ b/arc-spring-boot-starter/src/main/kotlin/ArcAutoConfiguration.kt
@@ -21,6 +21,7 @@ import org.eclipse.lmos.arc.agents.functions.LLMFunctionLoader
 import org.eclipse.lmos.arc.agents.functions.LLMFunctionProvider
 import org.eclipse.lmos.arc.agents.memory.InMemoryMemory
 import org.eclipse.lmos.arc.agents.memory.Memory
+import org.eclipse.lmos.arc.mcp.McpClientTransport
 import org.eclipse.lmos.arc.mcp.McpPromptRetriever
 import org.eclipse.lmos.arc.mcp.McpTools
 import org.eclipse.lmos.arc.spring.clients.ClientsConfiguration
@@ -59,7 +60,10 @@ open class ArcAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty("arc.mcp.prompts.url")
-    open fun mcpPromptRetriever(@Value("\${arc.mcp.prompts.url}") url: String): PromptRetriever = McpPromptRetriever(url)
+    open fun mcpPromptRetriever(
+        @Value("\${arc.mcp.prompts.url}") url: String,
+        @Value("\${arc.mcp.tools.transport:sse}") transportRaw: String,
+    ): PromptRetriever = McpPromptRetriever(url, McpClientTransport.fromConfiguration(transportRaw))
 
     @Bean
     open fun eventPublisher(eventHandlers: List<EventHandler<*>>) = BasicEventPublisher().apply {
@@ -92,9 +96,12 @@ open class ArcAutoConfiguration {
         functions: List<LLMFunction>,
         @Value("\${arc.mcp.tools.urls:}") urls: List<String>? = null,
         @Value("\${arc.mcp.tools.cache.duration:}") cacheDuration: Duration? = null,
+        @Value("\${arc.mcp.tools.transport:sse}") transportRaw: String,
     ): LLMFunctionProvider =
         CompositeLLMFunctionProvider(
-            loaders + (urls?.map { url -> McpTools(url, cacheDuration) } ?: emptyList()),
+            loaders + (urls?.map { url ->
+                McpTools(url, cacheDuration, McpClientTransport.fromConfiguration(transportRaw))
+            } ?: emptyList()),
             functions,
         )
 


### PR DESCRIPTION
- Introduce McpClientTransport (SSE vs streamable HTTP) and fromConfiguration
- Use HttpClientStreamableHttpTransport with POST /mcp; strip /sse from base URL when needed
- Plumb transport through McpTools, McpToolsByEnvironment, McpPromptRetriever, and ArcAutoConfiguration
- Add McpClientTransportTest; extend McpToolsByEnvironmentTest for ARC_MCP_TOOLS_TRANSPORT