### PR TITLE
feat: include processed use case content on UseCaseEvent

### DIFF
--- a/arc-assistants/src/main/kotlin/events/UseCaseEvents.kt
+++ b/arc-assistants/src/main/kotlin/events/UseCaseEvents.kt
@@ -15,4 +15,5 @@ data class UseCaseEvent(
     val step: String? = null,
     val version: String? = null,
     val description: String? = null,
+    val content: String? = null,
 ) : Event by BaseEvent()

--- a/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
+++ b/arc-assistants/src/main/kotlin/filters/UseCaseResponseHandler.kt
@@ -74,7 +74,16 @@ class UseCaseResponseHandler(
 
                 val loadedUseCases = getCurrentUseCases()
                 val useCase = loadedUseCases?.useCases?.find { it.id == useCaseId }
-                emit(UseCaseEvent(useCaseId, stepId, version = useCase?.version, description = useCase?.description))
+                val useCaseContent = loadedUseCases?.processedUseCaseMap?.get(useCaseId)
+                emit(
+                    UseCaseEvent(
+                        useCaseId,
+                        stepId,
+                        version = useCase?.version,
+                        description = useCase?.description,
+                        content = useCaseContent,
+                    ),
+                )
                 loadedUseCases?.let {
                     setCurrentUseCases(
                         it.copy(


### PR DESCRIPTION
Event handlers run outside the DSL context and cannot read outputContext or GraphQL response fields. Populate UseCaseEvent.content from processedUseCaseMap so downstream consumers can log full SOP text without ThreadLocal bridges.